### PR TITLE
XCPretty requires the name of the screenshot to be the name of the ro…

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -295,7 +295,7 @@ public func verifySnapshot<Value, Format>(
         failedSnapshotFileUrl = try createArtifacts(snapshotting: snapshotting,
                                                         artifacts: artifacts,
                                                         artifactsSubUrl: xcprettyReportDirectoryUrl,
-                                                        originTestName: testName)
+                                                        originTestName: name ?? testName)
       } else if let (failure, attachments) = attachmentDiff {
         let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
         failureMessage = failure


### PR DESCRIPTION
…ot test

Context: If you call out to a utility method to actually run your snapshot tests (and improve reusability) you need to pass the root test name separately